### PR TITLE
replace apostrophe with escape apostrophe instead of escape double quote

### DIFF
--- a/handlers/process/lib/render.js
+++ b/handlers/process/lib/render.js
@@ -10,7 +10,7 @@ const quoteTemplate = require('../../../templates/quote.json');
 
 const cleanString = async (string) => {
   let newString = string.replace(/(\r\n|\n|\r)/gm, '<br>');
-  newString = string.replace(/'/g, '&quot;');
+  newString = string.replace(/'/g, '&apos;');
   newString = newString.replace(/"/g, '&quot;');
   return newString;
 };


### PR DESCRIPTION
Escape apostrophes, per https://github.com/shotstack-samples/build-me-a-video-twitter-bot/issues/7.  I ultimately decided to just go with the regular apostrophe instead of the curly one because sometimes it's also used as the start of a single quote and parsing that is way more complex.